### PR TITLE
docs(pmo): Q2 2026 roadmap and tasks update

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # OSRS Bot Roadmap
 
-Last Updated: 2026-03-27
+Last Updated: 2026-04-03 (pmo/q2-2026-planning)
 
 ## 2026 Q1 (Completed)
 
@@ -13,6 +13,7 @@ Last Updated: 2026-03-27
 - [ ] Stabilize the container runtime entrypoint.
 - [ ] Reconcile the supported Python version across docs and Docker.
 - [ ] Improve OCR correction reliability and false-positive handling.
+- [ ] Add deterministic runtime health checks so long sessions can recover safely from stuck states.
 
 ## 2026 Q3 (Planned)
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,6 +1,6 @@
 # Tasks
 
-Last Updated: 2026-03-27
+Last Updated: 2026-04-03 (pmo/q2-2026-planning)
 
 ## Done
 
@@ -32,6 +32,11 @@ Last Updated: 2026-03-27
   - Priority: P1
   - Problem: long-running loops still lack strong runtime health checks.
   - Acceptance Criteria: low-health and stuck conditions trigger deterministic recovery actions.
+
+- [ ] Add deterministic runtime checkpoint logging.
+  - Priority: P2
+  - Problem: long-session troubleshooting lacks enough timestamped checkpoints to explain failures.
+  - Acceptance Criteria: key loop state (activity, location confidence, OCR confidence, last action) is logged periodically and summarized on failure.
 
 - [ ] Expand skill modules behind stable automation primitives.
   - Priority: P2


### PR DESCRIPTION
## Summary
- updates ROADMAP/TASKS planning for 2026 Q2 priorities
- preserves PMO-first flow before implementation (DEV flow follows after merge)
- keeps scope in markdown planning docs only

## Notes
- this PR is planning-only (no feature implementation)
- next phase is DEV flow to execute approved tasks after merge