### PR TITLE
pmo-cleanup: strip completed items from TASKS and ROADMAP

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,16 +1,13 @@
 # OSRS Bot Roadmap
 
-Last Updated: 2026-04-03 (pmo/q2-2026-planning)
+Last Updated: 2026-06-08
 
-## 2026 Q1 (Completed)
+## 2026 Q1 ✅
 
-- [x] Implement the core fishing and thieving automation loops.
-- [x] Add OCR-driven chat parsing and anti-bot response support.
-- [x] Add core utility coverage and baseline CI.
+> Completed. Core fishing and thieving automation loops, OCR-driven chat parsing, anti-bot response support, core utility coverage, baseline CI, and Docker entrypoint fix all shipped.
 
 ## 2026 Q2 (In Progress)
 
-- [ ] Stabilize the container runtime entrypoint.
 - [ ] Reconcile the supported Python version across docs and Docker.
 - [ ] Improve OCR correction reliability and false-positive handling.
 - [ ] Add deterministic runtime health checks so long sessions can recover safely from stuck states.
@@ -25,4 +22,3 @@ Last Updated: 2026-04-03 (pmo/q2-2026-planning)
 
 - [ ] Evaluate multi-account orchestration safety boundaries.
 - [ ] Evaluate operational controls for long-running autonomous sessions.
-

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,19 +1,6 @@
 # Tasks
 
-Last Updated: 2026-04-03 (pmo/q2-2026-planning)
-
-## Done
-
-- [x] Implement fishing and thieving automation modules.
-- [x] Add OCR and chat parsing helpers.
-- [x] Add automated tests for camera, compass, utils, and smoke paths.
-- [x] Add a baseline CI workflow.
-- [x] Fix the Docker runtime entrypoint.
-  - Priority: P0
-  - Problem: the container still starts with `python main.py`, but no root `main.py` exists.
-  - Acceptance Criteria: the container runs the documented bot entrypoint successfully.
-  - Completed: 2026-04-03
-  - Evidence: `Dockerfile` CMD updated to `python -m bot.core`; consistent with `docker-compose.yml` override.
+Last Updated: 2026-06-08
 
 ## In Progress
 
@@ -43,4 +30,3 @@ Last Updated: 2026-04-03 (pmo/q2-2026-planning)
   - Priority: P2
   - Problem: new skill work depends on more reliable shared movement and interaction primitives.
   - Acceptance Criteria: new skills reuse common primitives and ship with module-level tests.
-


### PR DESCRIPTION
## Summary

- Removes Done section from TASKS.md
- Collapses completed Q1 2026 items into a summary note in ROADMAP.md
- FEATURES.md unchanged (already has shipped/planned labels)

## Result

TASKS.md and ROADMAP.md contain only open Q2+ work.

Generated with Claude Code