### PR TITLE
docs: add session dashboard and behavioral profile ideas to Q4 roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,3 +22,5 @@ Last Updated: 2026-06-08
 
 - [ ] Evaluate multi-account orchestration safety boundaries.
 - [ ] Evaluate operational controls for long-running autonomous sessions.
+- [ ] **Session dashboard** — local-only web UI (served on `localhost`) that plots XP gained, actions per minute, and inventory events over a session timeline; gives the operator a glance-view without tailing log files.
+- [ ] **Behavioral profile system** — named automation profiles (`casual`, `focused`, `marathon`) that parametrize click variance, break frequency, and action cadence; decouples behavior tuning from code changes and makes long-session patterns more varied without editing source files.


### PR DESCRIPTION
## Summary
- Adds "Session dashboard" and "Behavioral profile system" as new Q4 exploratory items in ROADMAP.md
- Session dashboard: local-only web UI for live XP/action monitoring without log tailing
- Behavioral profile system: named automation configs to decouple behavior tuning from code edits

## Test plan
- [ ] Docs-only change; CI runs flake8 lint (no test failures from ROADMAP.md change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)